### PR TITLE
Improve Doom configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The core of the CI logic resides in this TypeScript file, executed by `ts-node`.
     -   Specifies `"type": "module"`, indicating the project uses ES Module syntax.
 -   **`tsconfig.json`**: Configures the TypeScript compiler options. It's set up for an ES Module project (`"module": "NodeNext"`).
 -   **`dagger.json`**: Dagger project file specifying the project name, SDK (typescript), and the main source file (`.dagger/config.ts`).
+-   **`config.org`**: Literate configuration tangled to `config.el` for Doom.
 
 ## Local Execution
 

--- a/config.org
+++ b/config.org
@@ -1,8 +1,11 @@
 #+title: Emacs Configuration
+#+PROPERTY: header-args:emacs-lisp :tangle config.el :comments link
 * Introduction
-* Initial
-** Basic
-#+begin_src emacs-lisp :tangle yes
+This org file contains the literate Doom Emacs configuration. All code
+blocks tangle to config.el for use by Doom.
+* Setup
+** Basic Setup
+#+begin_src emacs-lisp 
 (setq user-full-name    "Zhang Qingbo"
       user-mail-address "ripple0328@gmail.com"
       auth-sources '("~/.authinfo.gpg")
@@ -11,7 +14,8 @@
 
 #+end_src
 ** Dashboard
-#+begin_src emacs-lisp :tangle yes
+The Doom dashboard is customized with a splash image and no shortmenu.
+#+begin_src emacs-lisp 
 (remove-hook '+doom-dashboard-functions #'doom-dashboard-widget-shortmenu)
 (add-hook! '+doom-dashboard-functions :append
 (setq-hook! '+doom-dashboard-mode-hook evil-normal-state-cursor (list nil))
@@ -20,7 +24,8 @@
 #+end_src
 
 ** Visual
-#+begin_src emacs-lisp :tangle yes
+Theme and font settings for a consistent look across systems.
+#+begin_src emacs-lisp 
 (setq doom-theme 'modus-vivendi
 doom-font (font-spec :family "Iosevka Term SS04" :size 32 :weight 'light)
 doom-variable-pitch-font (font-spec :family "Iosevka Term SS04" :size 32)
@@ -31,8 +36,9 @@ doom-variable-pitch-font (font-spec :family "Iosevka Term SS04" :size 32)
    doom-variable-pitch-font (font-spec :family "Iosevka Term SS04" :size 16)))
 (setq-default line-spacing 0.24)
 #+end_src
-** Functional Configuration
-#+begin_src emacs-lisp :tangle yes
+** Core Behaviors
+General editor behaviour tweaks.
+#+begin_src emacs-lisp 
 (setq scroll-margin 2
       auto-save-default t
       display-line-numbers-type nil
@@ -51,15 +57,17 @@ doom-variable-pitch-font (font-spec :family "Iosevka Term SS04" :size 32)
       browse-url-browser-function 'xwidget-webkit-browse-url)
 #+end_src
 
-** web development
-#+begin_src emacs-lisp :tangle yes
+** Web Development
+Minor helpers for JS and TS workflows.
+#+begin_src emacs-lisp 
 (use-package jest-test-mode
   :ensure t
   :commands jest-test-mode
   :hook (typescript-tsx-mode js-mode typescript-mode))
 #+end_src
-** Mu4e
-#+begin_src emacs-lisp :tangle yes
+** Email
+Configuration for mu4e and Gmail.
+#+begin_src emacs-lisp 
 (after! mu4e
   (setq mu4e-index-cleanup nil
         mu4e-index-lazy-check t
@@ -85,8 +93,9 @@ doom-variable-pitch-font (font-spec :family "Iosevka Term SS04" :size 32)
   )
 )
 #+end_src
-** Org
-#+begin_src emacs-lisp :tangle yes
+** Org Mode
+Productivity features for Org.
+#+begin_src emacs-lisp 
  (after! org
    (map! :map org-mode-map
          :n "M-j" #'org-metadown
@@ -112,19 +121,24 @@ doom-variable-pitch-font (font-spec :family "Iosevka Term SS04" :size 32)
 #+end_src
 
 * Navigation
+Tools to move around projects.
 ** Treemacs
-#+begin_src emacs-lisp :tangle yes
+File tree viewer.
+#+begin_src emacs-lisp 
 (setq treemacs-follow-mode t)
 #+end_src
 ** Dirvish
-#+begin_src emacs-lisp: tangle yes
+Modern dired replacement.
+#+begin_src emacs-lisp
 (use-package! dirvish)
 #+end_src
 
-** keybinding
-#+begin_src emacs-lisp :tangle yes
+** Keybindings
+Custom leader mappings.
+#+begin_src emacs-lisp 
 (map! :leader
       :desc "other window"
       "w o" #'other-window)
 
 #+end_src
+


### PR DESCRIPTION
## Summary
- clean up literate config and add headings
- document customisation for each section
- mention `config.org` in the README

## Testing
- `npm ci`
- `npm run pipeline` *(fails: failed to download dagger cli)*

------
https://chatgpt.com/codex/tasks/task_e_684b65b14694832d80897f29efb98c02

## Summary by Sourcery

Improve Doom Emacs configuration documentation by cleaning up the literate config, adding section headings and customization details, and referencing config.org in the README.

Documentation:
- Clean up and structure the literate Doom config with clear headings in config.org
- Document customization options for each section of the Doom configuration
- Add a mention of config.org in the README for easier reference