### PR TITLE
Remove privacy doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,8 @@ To run the Dagger pipeline locally (assuming you have Node.js, npm, and Dagger C
         ```bash
         SKIP_DEPS=true npm run pipeline
         ```
+
+
+## User Identity
+
+Set `USER_FULL_NAME` and `USER_MAIL_ADDRESS` environment variables to populate your personal information when Emacs starts. The configuration defaults to empty strings if these variables are unset.

--- a/config.org
+++ b/config.org
@@ -6,8 +6,8 @@ blocks tangle to config.el for use by Doom.
 * Setup
 ** Basic Setup
 #+begin_src emacs-lisp 
-(setq user-full-name    "Zhang Qingbo"
-      user-mail-address "ripple0328@gmail.com"
+(setq user-full-name    (or (getenv "USER_FULL_NAME") "")
+      user-mail-address (or (getenv "USER_MAIL_ADDRESS") "")
       auth-sources '("~/.authinfo.gpg")
       major-mode 'org-mode
 )
@@ -76,7 +76,7 @@ Configuration for mu4e and Gmail.
         message-send-mail-function 'smtpmail-send-it
         mu4e-maildir-shortcuts '((
                                 :maildir "/inbox" :key ?i))
-        smtpmail-auth-credentials '(("smtp.gmail.com" 587 "ripple0328@gmail.com" nil))
+        smtpmail-auth-credentials (list (list "smtp.gmail.com" 587 user-mail-address nil))
         smtpmail-default-smtp-server "smtp.gmail.com"
         smtpmail-smtp-server "smtp.gmail.com"
         smtpmail-smtp-service 587)
@@ -86,10 +86,10 @@ Configuration for mu4e and Gmail.
     (mu4e-drafts-folder     . "/Gmail/Drafts")
     (mu4e-trash-folder      . "/Gmail/Trash")
     (mu4e-refile-folder     . "/Gmail/All Mail")
-    (smtpmail-smtp-user     . "ripple0328@gmail.com")
+    (smtpmail-smtp-user     . user-mail-address)
     (mu4e-get-mail-command  . "mbsync --all")
-    (user-mail-address      . "ripple0328@gmail.com")    ;; only needed for mu < 1.4
-    (mu4e-compose-signature . "---\n Qingbo Zhang"))
+    (user-mail-address      . user-mail-address)
+    (mu4e-compose-signature . (or (getenv "EMAIL_SIGNATURE") "") )
   )
 )
 #+end_src


### PR DESCRIPTION
## Summary
- drop the standalone privacy document
- switch personal details in `config.org` to environment variables
- document new `USER_FULL_NAME` and `USER_MAIL_ADDRESS` variables in README

## Testing
- `npm ci`
- `SKIP_DEPS=true npm run pipeline` *(fails: failed to download dagger cli)*

------
https://chatgpt.com/codex/tasks/task_e_684b72aaa7f0832d9576bdda6640a380

## Summary by Sourcery

Remove the standalone privacy document, migrate personal details to environment variables, and update the README with new USER_FULL_NAME and USER_MAIL_ADDRESS documentation.

Enhancements:
- Switch personal details in config.org to use USER_FULL_NAME and USER_MAIL_ADDRESS environment variables.

Documentation:
- Remove the standalone privacy document.
- Add documentation for USER_FULL_NAME and USER_MAIL_ADDRESS environment variables in the README.